### PR TITLE
Feat: 게시판 글, 회원을 위한 엔티티 추가

### DIFF
--- a/src/main/java/com/seonjuleee/querydslstudy/entity/BaseEntity.java
+++ b/src/main/java/com/seonjuleee/querydslstudy/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.seonjuleee.querydslstudy.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/seonjuleee/querydslstudy/entity/Post.java
+++ b/src/main/java/com/seonjuleee/querydslstudy/entity/Post.java
@@ -1,0 +1,29 @@
+package com.seonjuleee.querydslstudy.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(of = {"id", "title", "content"})
+public class Post extends BaseEntity {
+    @Id @GeneratedValue
+    @Column(name = "post_id")
+    private Long id;
+    private String title;
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public Post(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/seonjuleee/querydslstudy/entity/User.java
+++ b/src/main/java/com/seonjuleee/querydslstudy/entity/User.java
@@ -1,0 +1,26 @@
+package com.seonjuleee.querydslstudy.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(of = {"id", "name"})
+public class User extends BaseEntity {
+    @Id @GeneratedValue
+    @Column(name = "user_id")
+    private Long id;
+    private String name;
+
+    public User(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
## Description
- resolved: #5 
- 도메인 모델 설계 후 엔티티를 추가함
![querydsl-study-1 drawio](https://user-images.githubusercontent.com/52817735/216767238-4485fb43-eba0-4e3f-8c7d-e30af2b5d5fc.png)
예제에서는 팀과 멤버를 1:N 양방향 설계했지만, 양방향보단 단방향이 권장되므로 단방향(Post -> User) 설계하였음.